### PR TITLE
fix: Startup process issues

### DIFF
--- a/kubespider/core/config_handler.py
+++ b/kubespider/core/config_handler.py
@@ -140,7 +140,7 @@ def prepare_config() -> None:
         miss_cfg.append(values.Config.DOWNLOAD_PROVIDER)
     if not os.path.exists(values.Config.PT_PROVIDER.config_path()):
         miss_cfg.append(values.Config.PT_PROVIDER)
-    if not os.path.exists(values.Config.KUBESPIDER_CONFIG):
+    if not os.path.exists(values.Config.KUBESPIDER_CONFIG.config_path()):
         miss_cfg.append(values.Config.KUBESPIDER_CONFIG)
 
     if len(miss_cfg) == 0:

--- a/kubespider/core/kubespider_controller.py
+++ b/kubespider/core/kubespider_controller.py
@@ -2,7 +2,6 @@
 
 import logging
 import _thread
-import time
 
 from core import download_trigger
 from core import period_server
@@ -84,8 +83,6 @@ class Kubespider:
         _thread.start_new_thread(self.run_download_trigger_job, ())
         _thread.start_new_thread(self.run_pt_server, ())
 
-        while True:
-            time.sleep(30)
 
 kubespider_controller = Kubespider()
 

--- a/kubespider/core/runner.py
+++ b/kubespider/core/runner.py
@@ -26,6 +26,9 @@ def run() -> None:
     # webhook doesn't belong to kubespider_controller, so let's extract it here
     _thread.start_new_thread(run_webhook_server, ())
 
+    while True:
+        time.sleep(30)
+
 def run_with_config_handler():
     logging.basicConfig(level=logging.INFO, format='%(asctime)s-%(levelname)s: %(message)s')
     config_handler.prepare_config()


### PR DESCRIPTION
- kubespider.yaml file exits check add config_path()
- move "while true" after the startup of the webhook_server

Fixes #175 