### PR TITLE
fix: Fix getting download providers' name list

### DIFF
--- a/kubespider/download_provider/transmission_download_provider/provider.py
+++ b/kubespider/download_provider/transmission_download_provider/provider.py
@@ -79,9 +79,9 @@ class TransmissionProvider(
     def load_config(self) -> TypeError:
         cfg = self.config_reader.read()
         self.download_base_path = cfg['download_base_path']
-        http_endpoint = cfg['http_endpoint']
-        username = cfg['username']
-        password = cfg['password']
+        http_endpoint = cfg.get('http_endpoint')
+        username = cfg.get('username', 'admin')
+        password = cfg.get('password', 'admin')
 
         parse_result = urlparse(http_endpoint)
 

--- a/kubespider/source_provider/bilibili_source_provider/provider.py
+++ b/kubespider/source_provider/bilibili_source_provider/provider.py
@@ -31,7 +31,10 @@ class BilibiliSourceProvider(provider.SourceProvider):
         return "youget_download_provider"
 
     def get_prefer_download_provider(self) -> list:
-        return self.config_reader.read().get('downloader')
+        downloader_name = self.config_reader.read().get('downloader', None)
+        if downloader_name is None:
+            return None
+        return [downloader_name]
 
     def get_download_param(self) -> list:
         return self.config_reader.read().get('download_param')

--- a/kubespider/source_provider/general_rss_source_provider/provider.py
+++ b/kubespider/source_provider/general_rss_source_provider/provider.py
@@ -56,7 +56,10 @@ class GeneralRssSourceProvider(provider.SourceProvider):
         pass
 
     def get_prefer_download_provider(self) -> None:
-        return self.config_reader.read().get('downloader')
+        downloader_name = self.config_reader.read().get('downloader', None)
+        if downloader_name is None:
+            return None
+        return [downloader_name]
 
     def get_provider_listen_type(self) -> str:
         return self.provider_listen_type

--- a/kubespider/source_provider/magic_source_provider/provider.py
+++ b/kubespider/source_provider/magic_source_provider/provider.py
@@ -42,7 +42,10 @@ class MagicSourceProvider(provider.SourceProvider):
         pass
 
     def get_prefer_download_provider(self) -> list:
-        return self.config_reader.read().get('downloader', None)
+        downloader_name = self.config_reader.read().get('downloader', None)
+        if downloader_name is None:
+            return None
+        return [downloader_name]
 
     def get_download_param(self) -> list:
         return self.config_reader.read().get('download_param')

--- a/kubespider/source_provider/meijutt_source_provider/provider.py
+++ b/kubespider/source_provider/meijutt_source_provider/provider.py
@@ -36,7 +36,10 @@ class MeijuttSourceProvider(provider.SourceProvider):
         return None
 
     def get_prefer_download_provider(self) -> list:
-        return self.config_reader.read().get('downloader')
+        downloader_name = self.config_reader.read().get('downloader', None)
+        if downloader_name is None:
+            return None
+        return [downloader_name]
 
     def get_download_param(self) -> list:
         return self.config_reader.read().get('download_param')

--- a/kubespider/source_provider/mikanani_source_provider/provider.py
+++ b/kubespider/source_provider/mikanani_source_provider/provider.py
@@ -38,7 +38,10 @@ class MikananiSourceProvider(provider.SourceProvider):
         return None
 
     def get_prefer_download_provider(self) -> list:
-        return self.config_reader.read().get('downloader')
+        downloader_name = self.config_reader.read().get('downloader', None)
+        if downloader_name is None:
+            return None
+        return [downloader_name]
 
     def get_download_param(self) -> list:
         return self.config_reader.read().get('download_param')

--- a/kubespider/source_provider/tiktok_source_provider/provider.py
+++ b/kubespider/source_provider/tiktok_source_provider/provider.py
@@ -30,7 +30,10 @@ class TiktokSourceProvider(provider.SourceProvider):
         return 'tiktok_download_provider'
 
     def get_prefer_download_provider(self) -> list:
-        return self.config_reader.read().get('downloader')
+        downloader_name = self.config_reader.read().get('downloader', None)
+        if downloader_name is None:
+            return None
+        return [downloader_name]
 
     def get_download_param(self) -> list:
         return self.config_reader.read().get('download_param')

--- a/kubespider/source_provider/youtube_source_provider/provider.py
+++ b/kubespider/source_provider/youtube_source_provider/provider.py
@@ -34,7 +34,10 @@ class YouTubeSourceProvider(provider.SourceProvider):
         return self.config_reader.read().get('download_param')
 
     def get_prefer_download_provider(self) -> list:
-        return self.config_reader.read().get('downloader')
+        downloader_name = self.config_reader.read().get('downloader', None)
+        if downloader_name is None:
+            return None
+        return [downloader_name]
 
     def get_link_type(self) -> str:
         return self.link_type

--- a/kubespider/test/source_provider/test_mikanani_source_provider.py
+++ b/kubespider/test/source_provider/test_mikanani_source_provider.py
@@ -24,7 +24,7 @@ class MikkananiSouirceProviderTest(unittest.TestCase):
 
     def test_read_config(self):
         downloader = self.provider.get_prefer_download_provider()
-        self.assertEqual(downloader, 'test_downloader')
+        self.assertEqual(downloader, ['test_downloader'])
         param = self.provider.get_download_param()
         self.assertEqual({'tags': ["test"]}, param)
 


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

When obtaining download providers, we should return a list instead of a string. If one source provider configures the download provider as `abc`, and there are `ab` and `bc` providers available, it will match them, but this is not the expected behavior.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```