### PR TITLE
fix: KubespiderDownloader.__init__ param type

### DIFF
--- a/kubespider/core/download_trigger.py
+++ b/kubespider/core/download_trigger.py
@@ -8,8 +8,8 @@ import source_provider.provider as sp
 
 
 class KubespiderDownloader:
-    def __init__(self, download_providers: dp.DownloadProvider):
-        self.download_providers: dp.DownloadProvider = download_providers
+    def __init__(self, download_providers: list[dp.DownloadProvider]):
+        self.download_providers: list[dp.DownloadProvider] = download_providers
 
     def period_run(self):
         while True:

--- a/kubespider/core/pt_server.py
+++ b/kubespider/core/pt_server.py
@@ -19,7 +19,7 @@ class PTServer:
 
         self.single_file_threshold = config_reader.read().get('pt_single_max_size', 100.0)
         self.sum_file_threshold = config_reader.read().get('pt_sum_max_size', 100.0)
-        self.seeding_time = config_reader.read().get('pt_seeding_time') * 3600
+        self.seeding_time = config_reader.read().get('pt_seeding_time', 48) * 3600
 
         self.state_config = YamlFileConfigReader(Config.STATE.config_path())
         state = self.state_config.read().get('pt_state', {})


### PR DESCRIPTION
Fixes #none

**Release Note**
- The constructor parameter for `KubespiderDownloader` should be of type list.
- Set a default value for the `seeding_time` field in the `PTServer`.