### PR TITLE
feat: chrome-ext trigger download support capture cookies.

### DIFF
--- a/chrome-extension/js/kubespider.js
+++ b/chrome-extension/js/kubespider.js
@@ -10,10 +10,10 @@ async function sendRequest() {
         return;
     }
 
-    let { path, server, token } = await chrome.storage.sync.get(['path', 'server', 'token']);
+    let {path, server, token} = await chrome.storage.sync.get(['path', 'server', 'token']);
 
     if (path !== inputPath) {
-        chrome.storage.sync.set({ 'path': inputPath }, () => {
+        chrome.storage.sync.set({'path': inputPath}, () => {
             console.log('path set successed!');
         });
     }
@@ -26,7 +26,7 @@ async function sendRequest() {
         return;
     }
 
-    let data = { "dataSource": dataSource, "path": inputPath };
+    let data = {"dataSource": dataSource, "path": inputPath};
     try {
         let response = await fetch(`${server}/api/v1/download`, {
             method: "POST",
@@ -65,6 +65,8 @@ async function saveConfig() {
     let authEnable = document.getElementById('auth').checked;
     let token = document.getElementById('token').value;
 
+    let captureCookies = document.getElementById('capture_cookies').checked;
+
     saveBtn.classList.add('btn-loading');
     try {
         let response = await fetch(`${serverValue}/healthz`, {
@@ -80,6 +82,7 @@ async function saveConfig() {
                 server: serverValue,
                 auth: authEnable,
                 token: token,
+                captureCookies: captureCookies,
             });
             await sleep(3000);
             saveBtn.classList.remove('btn-success');
@@ -103,12 +106,12 @@ async function saveConfig() {
 }
 
 function openGitHub() {
-    chrome.tabs.create({ url: "https://github.com/opennaslab/kubespider" });
+    chrome.tabs.create({url: "https://github.com/opennaslab/kubespider"});
 }
 
 async function refreshDownload() {
     let refreshBtn = document.getElementById('refresh');
-    let { server, token } = await chrome.storage.sync.get('server');
+    let {server, token} = await chrome.storage.sync.get(['server', 'token']);
     if (!server) return;
 
     refreshBtn.classList.add('btn-loading');
@@ -150,25 +153,17 @@ async function displayAuthInfoInput(event) {
     let authInput = document.getElementById('auth')
     let inputGroup = document.getElementById('authInputGroup')
     inputGroup.hidden = !authInput.checked;
-    if (authInput.checked) {
-        document.querySelector('body').style.height = "280px";
-    } else {
-        document.querySelector('body').style.height = "220px";
-    }
 }
 
 /**
  * read chrome store config
  */
-chrome.storage.sync.get(['server', 'path', 'auth', 'token']).then((res) => {
+chrome.storage.sync.get(['server', 'path', 'auth', 'token', 'captureCookies']).then((res) => {
     // check enable auth & change style
     if (res.auth) {
         document.getElementById('auth').checked = res.auth;
         let inputGroup = document.getElementById('authInputGroup')
         inputGroup.hidden = !res.auth;
-        if (res.auth) {
-            document.querySelector('body').style.height = "280px";
-        }
     }
     // read config
     if (res.token) {
@@ -179,6 +174,9 @@ chrome.storage.sync.get(['server', 'path', 'auth', 'token']).then((res) => {
     }
     if (res.path) {
         document.getElementById('path').value = res.path;
+    }
+    if (res.captureCookies) {
+        document.getElementById('capture_cookies').checked = res.captureCookies;
     }
 })
 

--- a/chrome-extension/kubespider.html
+++ b/chrome-extension/kubespider.html
@@ -52,7 +52,7 @@
     }
   </style>
 </head>
-<body style="width: 300px; height: 220px; margin-top: 5px;">
+<body style="width: 300px; height: auto; padding: 5px 0 10px 0;">
     <div class="container">
         <ul class="nav nav-tabs">
             <li class="nav-item">
@@ -82,20 +82,26 @@
                 <button type="button" class="btn btn-primary btn-sm" id="download">Download</button>
             </div>
             <div id="configPage" class="tab-pane fade">
-                <div class="input-group pos input-group-sm mb-3">
+                <div class="input-group input-group-sm mb-3">
                     <span class="input-group-text">SERVER</span>
                     <input type="text" class="form-control form-control-sm" placeholder="server" id="server">
                 </div>
-                <div class="input-group pos input-group-sm mb-3">
+                <div class="input-group input-group-sm mb-3">
                     <div class="form-check form-switch">
                         <input class="form-check-input" type="checkbox" role="switch" id="auth">
                         <label class="form-check-label" for="auth">enable auth</label>
                     </div>
                 </div>
                 <div id="authInputGroup" hidden="hidden">
-                    <div class="input-group pos input-group-sm mb-3">
+                    <div class="input-group input-group-sm mb-3">
                         <span class="input-group-text">TOKEN</span>
                         <input type="text" class="form-control form-control-sm" placeholder="token" id="token">
+                    </div>
+                </div>
+                <div class="input-group input-group-sm mb-3" hidden="hidden">
+                    <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" role="switch" id="capture_cookies">
+                        <label class="form-check-label" for="capture_cookies">capture cookies</label>
                     </div>
                 </div>
                 <button type="button" class="btn btn-primary btn-sm" id="save">Save</button>

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,14 +1,15 @@
 {
     "name": "Kubespider",
     "manifest_version": 3,
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Trigger Kubespider execute downloading task",
     "permissions": [
       "storage",
       "declarativeNetRequest",
       "declarativeNetRequestFeedback",
       "contextMenus",
-      "tabs"
+      "tabs",
+      "cookies"
     ],
     "action": {
       "default_title": "Kubespider",

--- a/chrome-extension/service_worker.js
+++ b/chrome-extension/service_worker.js
@@ -10,54 +10,59 @@ function sleep(time) {
     return new Promise((resolve) => setTimeout(resolve, time));
 }
 
-function handleRequestSend(link, tab, server, token) {
-    let dataSource = tab.url;
-    if (link != null) {
-        dataSource = link;
+async function badgeText(showText) {
+    chrome.action.setBadgeText({text: showText});
+    await sleep(9000);
+    chrome.action.setBadgeText({text: ''});
+}
+
+async function handleRequestSend(linkUrl, tabUrl) {
+
+    let dataSource = linkUrl;
+    if (dataSource === "" || dataSource == null) {
+        dataSource = tabUrl;
+    }
+
+    let {server, token, captureCookies} = await chrome.storage.sync.get(['server', 'token', 'captureCookies']);
+    if (!server) {
+        await badgeText('FAIL');
+        return;
     }
 
     chrome.action.setBadgeText({text: 'GO'});
+
     let data = {"dataSource": dataSource, "path": ""};
-    fetch(server + '/api/v1/download', {
-        method: 'POST',
-        mode: 'cors',
-        headers: {
-            "Content-type": "application/json",
-            "Authorization": `Bearer ${token}`,
-        },
-        body: JSON.stringify(data),
-    }).then(response => {
-        if (response.status === 200) {
-            chrome.action.setBadgeText({text: 'OK'});
-            sleep(9000).then(() => {
-                chrome.action.setBadgeText({text: ''});
-            });
-        } else {
-            chrome.action.setBadgeText({text: 'FAIL'});
-            sleep(9000).then(() => {
-                chrome.action.setBadgeText({text: ''});
-            });
-        }
-    }).catch(error => {
-        chrome.action.setBadgeText({text: 'FAIL'});
-        sleep(9000).then(() => {
-            chrome.action.setBadgeText({text: ''});
+
+    if (captureCookies) {
+        let cookies = await chrome.cookies.getAll({url: tabUrl});
+        data.cookies = cookies.map((cookie) => {
+            return `${cookie.name}=${cookie.value}`;
+        }).join(';');
+    }
+
+    try {
+        console.log(JSON.stringify(data));
+        let response = await fetch(server + '/api/v1/download', {
+            method: 'POST',
+            mode: 'cors',
+            headers: {
+                "Content-type": "application/json",
+                "Authorization": `Bearer ${token}`,
+            },
+            body: JSON.stringify(data),
         });
-    })
+        if (response.status === 200) {
+            await badgeText('OK');
+        } else {
+            await badgeText('FAIL');
+        }
+    } catch (error) {
+        await badgeText('FAIL');
+    }
 }
 
 chrome.contextMenus.onClicked.addListener(function (info, tab) {
     if (info.menuItemId === "KubespiderMenu") {
-        chrome.storage.sync.get(['server', 'token'], (res) => {
-            if (!res.server) {
-                document.getElementById('server').value = "";
-                chrome.action.setBadgeText({text: 'FAIL'});
-                sleep(9000).then(() => {
-                    chrome.action.setBadgeText({text: ''});
-                });
-                return
-            }
-            handleRequestSend(info.linkUrl, tab, res.server, res.token);
-        });
+        handleRequestSend(info.linkUrl, tab.url);
     }
-})
+});


### PR DESCRIPTION
Fixes #none

**Release Note**

- chrome ext send task，both send tab.url cookies.
- Temporarily hidden by default, after release when api stable.