### PR TITLE
fix: webhook trigger extra param key 'cookies'

### DIFF
--- a/kubespider/core/source_manager.py
+++ b/kubespider/core/source_manager.py
@@ -4,7 +4,7 @@ from api import types
 from api.values import Resource, Event, Downloader
 from utils import helper
 from source_provider.provider import SourceProvider
-from core.period_server import kubespider_period_server
+from core import period_server
 from core import download_trigger
 
 
@@ -38,7 +38,7 @@ class SourceProviderManager:
         else:
             if match_provider.get_provider_listen_type() == types.SOURCE_PROVIDER_PERIOD_TYPE:
                 match_provider.update_config(event)
-                err = kubespider_period_server.run_single_provider(match_provider)
+                err = period_server.kubespider_period_server.run_single_provider(match_provider)
             else:
                 links = match_provider.get_links(event)
                 if links is None or len(links) == 0:

--- a/kubespider/source_provider/magic_source_provider/provider.py
+++ b/kubespider/source_provider/magic_source_provider/provider.py
@@ -72,7 +72,7 @@ class MagicSourceProvider(provider.SourceProvider):
     def get_links(self, event: Event) -> list[Resource]:
         ret = []
         try:
-            controller = helper.get_request_controller(event.extra_param('cookie', self.cookie))
+            controller = helper.get_request_controller(event.extra_param('cookies', self.cookie))
             resp = controller.get(event.source, timeout=30).content
         except Exception as err:
             logging.warning('MagicSourceProvider get links error:%s', err)
@@ -127,7 +127,7 @@ class MagicSourceProvider(provider.SourceProvider):
 
     def pre_download_file(self, event: Event, links: list) -> list:
         ret = []
-        controller = helper.get_request_controller(event.extra_param('cookie', self.cookie))
+        controller = helper.get_request_controller(event.extra_param('cookies', self.cookie))
         for link in links:
             file = helper.download_torrent_file(link, controller)
             if file is not None:
@@ -137,7 +137,7 @@ class MagicSourceProvider(provider.SourceProvider):
 
     def filter_links(self, event: Event, links: list) -> list:
         ret = []
-        controller = helper.get_request_controller(event.extra_param('cookie', self.cookie))
+        controller = helper.get_request_controller(event.extra_param('cookies', self.cookie))
         for link in links:
             # For this situation(the href is "text.torrent"), we need to construct the link
             link_current = link

--- a/kubespider/utils/helper.py
+++ b/kubespider/utils/helper.py
@@ -63,10 +63,7 @@ def get_link_type(url: str, controller: requests.Session) -> str:
         return types.LINK_TYPE_TORRENT
     # rfc6266: guess link type
     try:
-        resp = controller.head(url, timeout=30)
-        redirect_url = resp.headers.get('location', None)
-        if redirect_url is not None:
-            resp = controller.head(redirect_url, timeout=30)
+        resp = controller.head(url, timeout=30, allow_redirects=True)
         if resp.status_code == 200 and resp.headers.get('content-disposition'):
             content_disposition = resp.headers.get('content-disposition')
             _, params = cgi.parse_header(content_disposition)


### PR DESCRIPTION
Fixes #

* kubespider-extension send tab cookies use 'cookies'.