### PR TITLE
fix: Issue with path when source_provider is not matched

### DIFF
--- a/docs/zh/user_guide/tiktok_download_provider/README.md
+++ b/docs/zh/user_guide/tiktok_download_provider/README.md
@@ -97,7 +97,7 @@ docker restart kubespider
 
 ## 友情提示
 
-使用iOS的用户，可以使用快捷指令，参考：[kubespider](https://www.icloud.com/shortcuts/c773b469c21640908e33eda8617b5f63)
+使用iOS的用户，可以使用快捷指令，参考：[kubespider](https://www.icloud.com/shortcuts/86a4dfb7b66046c8a8015637cfbd50c5)
 
 添加后，直接分享到快捷指令，即可下载。
 

--- a/kubespider/core/source_manager.py
+++ b/kubespider/core/source_manager.py
@@ -28,9 +28,10 @@ class SourceProviderManager:
         if match_provider is None:
             controller = helper.get_request_controller(event.extra_param('cookies'))
             link_type = helper.get_link_type(event.source, controller)
+            path = os.path.join(helper.convert_file_type_to_path(types.FILE_TYPE_COMMON), event.path)
             err = download_trigger.kubespider_downloader.download_file(Resource(
                 url=event.source,
-                path=event.path,
+                path=path,
                 file_type=types.FILE_TYPE_COMMON,
                 link_type=link_type,
                 **event.extra_params()


### PR DESCRIPTION
Fixes #
- When source_provider is not matched, the path is not correctly concatenated with the file_type prefix.
- Replace the shortcut link, make the path configuration more clear