### PR TITLE
init Release Chrome Extension action

### DIFF
--- a/.github/workflows/release-extension.yaml
+++ b/.github/workflows/release-extension.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Kubespider
+# Copyright 2023 Kubespider
 # SPDX-License-Identifier: Apache-2.0
 
 name: Release Chrome Extension

--- a/.github/workflows/release-extension.yaml
+++ b/.github/workflows/release-extension.yaml
@@ -1,0 +1,34 @@
+# Copyright 2022 Kubespider
+# SPDX-License-Identifier: Apache-2.0
+
+name: Release Chrome Extension
+on:
+  push:
+    tags:
+      - "extension-v*.*.*"
+jobs:
+  Release-Extension:
+    name: Release Kubespider Chrome Extension
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Extract Release Tag and Commit SHA
+      id: vars
+      shell: bash
+      run: |
+        echo "release_tag=$(echo ${GITHUB_REF#refs/tags/extension-})" >> $GITHUB_ENV
+
+    # pack zip and read manifest, can be reused in the following steps
+    - id: packExtensionDir
+      uses: cardinalby/webext-buildtools-pack-extension-dir-action@v1
+      with:
+        extensionDir: 'chrome-extension'
+        zipFilePath: 'chrome-extension-${{env.release_tag}}.zip'
+
+    - name: Upload Release Manifests
+      uses: softprops/action-gh-release@v1
+      with:
+        name: Chrome Extension ${{env.release_tag}}
+        files: |
+          chrome-extension-${{env.release_tag}}.zip


### PR DESCRIPTION
fixes: https://github.com/opennaslab/kubespider/issues/325


How to use: 
- Create a tag with prefix `extension-v`, e.g. `extesion-v0.2.0`

see demo: https://github.com/zirain/kubespider/actions/runs/6064872582 and https://github.com/zirain/kubespider/actions/runs/6064872582

Best Practices:

keep tag suffix same with `manifest.json`