### PR TITLE
fix: fix btbtt12 downloading

### DIFF
--- a/kubespider/source_provider/btbtt12_disposable_source_provider/provider.py
+++ b/kubespider/source_provider/btbtt12_disposable_source_provider/provider.py
@@ -75,6 +75,7 @@ class Btbtt12DisposableSourceProvider(provider.SourceProvider):
             url=ret,
             path=title,
             file_type=file_type,
+            link_type=self.get_link_type(),
         )]
 
     def update_config(self, event: Event) -> None:


### PR DESCRIPTION
修复通过浏览器插件向kubespider发送btbtt12的下载链接可能不能正常下载的情况

Fixes https://github.com/opennaslab/kubespider/issues/336

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```