### PR TITLE
simply download youtube by default config

### DIFF
--- a/.config/download_provider.yaml
+++ b/.config/download_provider.yaml
@@ -8,6 +8,12 @@ yt-dlp:
   target_format: mp4
   download_proxy: http://192.168.1.8:1087
   priority: 0
+  handle_host:
+    - www.youtube.com
+    - youtube.com
+    - www.ted.com
+    - youtu.be
+    - m.youtube.com
 youget:
   type: youget_download_provider
   enable: false

--- a/kubespider/download_provider/ytdlp_download_provider/provider.py
+++ b/kubespider/download_provider/ytdlp_download_provider/provider.py
@@ -77,4 +77,4 @@ class YTDlpDownloadProvider(DownloadProvider):
         self.auto_convert = cfg.get('auto_format_convet', False)
         self.target_format = cfg.get('target_format', 'mp4')
         self.download_proxy = cfg.get('download_proxy', '')
-        self.handle_host = cfg.get('handle_host', ['www.youtube.com'])
+        self.handle_host = cfg.get('handle_host', ['www.youtube.com', 'youtube.com', 'm.youtube.com', 'youtu.be'])


### PR DESCRIPTION
Currently, these configurations are scattered in various places, and later, there is consideration to optimize and consolidate the configuration of YouTube’s URLs.