### PR TITLE
refactor(ui/config): Modify the configuration file read policy

### DIFF
--- a/.config/kubespider.yaml
+++ b/.config/kubespider.yaml
@@ -1,11 +1,11 @@
 ---
-# This address will be as http/https proxy
-proxy:
+log:
+  level: INFO
+proxy: ''
 webapi:
-  # This port will be used to provide the api service
   server_port: 3080
-  # The auth_token will be used auth the api
-  auth_token:
+  auth_token: ''
+  secret_key: iECgbYWReMNxkRprrzMo5KAQYnb2UeZ3bwvReTSt+VSESW0OB8zbglT+6rEcDW9X
 statemachine:
   task_queue_size: 100
   event_queue_size: 100

--- a/kubespider/app.py
+++ b/kubespider/app.py
@@ -2,6 +2,7 @@ import logging
 import sys
 
 from core import runner
+from utils.global_config import cfg
 
 
 def check_python_version():
@@ -13,8 +14,11 @@ def check_python_version():
 
 
 def main():
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s-%(levelname)s: %(message)s')
-    runner.run_with_config_handler()
+    if cfg.log.level == 'DEBUG':
+        logging.basicConfig(level=logging.DEBUG, format='%(asctime)s-%(levelname)s %(filename)s[line%(lineno)d]: %(message)s')
+    else:
+        logging.basicConfig(level=logging.INFO, format='%(asctime)s-%(levelname)s: %(message)s')
+    runner.run()
 
 
 if __name__ == "__main__":

--- a/kubespider/core/api/__init__.py
+++ b/kubespider/core/api/__init__.py
@@ -21,7 +21,7 @@ def create_app():
 
     @app.before_request
     def get_auth():
-        if Config.AUTH_TOKEN is None:
+        if not Config.AUTH_TOKEN:
             g.auth = True
         else:
             if request.headers is None:

--- a/kubespider/core/api/v2/source_provider/views.py
+++ b/kubespider/core/api/v2/source_provider/views.py
@@ -4,7 +4,8 @@ from flask import jsonify, request, current_app
 
 from core.api.response import success, server_error, param_error
 from core.api.v2.source_provider import source_provider_blu
-from utils.values import ProviderApiSaveParams, Config
+from utils.values import ProviderApiSaveParams
+from utils.global_config import PathConfig
 
 
 @source_provider_blu.route("/spec", methods=["GET"])
@@ -21,7 +22,7 @@ def upload_source_provider():
     file = request.files['file']
     if file.filename == '' or not file:
         return param_error(msg="No selected file")
-    file.save(os.path.join(Config.SOURCE_PROVIDERS_BIN.config_path(), file.filename))
+    file.save(os.path.join(PathConfig.SOURCE_PROVIDERS_BIN.config_path(), file.filename))
     return success(msg="File uploaded successfully")
 
 

--- a/kubespider/core/middleware/source_provider/sdk_source_provider/provider.py
+++ b/kubespider/core/middleware/source_provider/sdk_source_provider/provider.py
@@ -8,8 +8,7 @@ import requests
 
 from core.exceptions import UnSupportedMethod
 from core.middleware.source_provider.provider import SourceProvider
-from utils import values
-from utils.global_config import Config
+from utils.global_config import Config, PathConfig
 from utils.values import SourceProviderApi
 
 
@@ -26,7 +25,7 @@ class SdkSourceProvider(SourceProvider):
 
     @staticmethod
     def spec():
-        binary_path = values.Config.SOURCE_PROVIDERS_BIN.config_path()
+        binary_path = PathConfig.SOURCE_PROVIDERS_BIN.config_path()
         binaries = [os.path.join(binary_path, b) for b in os.listdir(binary_path)]
         specs = []
         for binary in binaries:

--- a/kubespider/core/runner.py
+++ b/kubespider/core/runner.py
@@ -4,10 +4,9 @@ import logging
 import waitress
 
 from core.api import create_app
-from utils.global_config import Config, initdirs
+from utils.global_config import Config
 
 
 def run() -> None:
     logging.info('Webhook Server start running...')
-    initdirs()
     waitress.serve(create_app(), host='0.0.0.0', port=Config.SERVER_PORT)

--- a/kubespider/core/runner.py
+++ b/kubespider/core/runner.py
@@ -4,16 +4,10 @@ import logging
 import waitress
 
 from core.api import create_app
-from core import config_handler
-from utils.global_config import Config
+from utils.global_config import Config, initdirs
 
 
 def run() -> None:
     logging.info('Webhook Server start running...')
+    initdirs()
     waitress.serve(create_app(), host='0.0.0.0', port=Config.SERVER_PORT)
-
-
-def run_with_config_handler():
-    config_handler.prepare_config()
-    logging.info('Config Prepare finish...')
-    run()

--- a/kubespider/utils/config_reader.py
+++ b/kubespider/utils/config_reader.py
@@ -1,9 +1,117 @@
+import logging
 import threading
 import os
 from abc import ABC, abstractmethod
 
 import yaml
 
+class StructConfig:
+    """
+    StructConfig is a warp struct for dict config.
+    
+    Example:
+    
+    dictionary = {
+        'A': 123,
+        'B': {
+            'b': 22,
+        },
+    }
+
+    cfg = StructConfig(dictionary)
+
+    print(cfg.a)   # 123
+    print(cfg.B.B) # 22
+
+    StructConfig will replace the yaml value from env
+
+    Example:
+
+    export A = 456
+    export B_FOO = 'World'
+
+    dictionary = {
+        'A': 123,
+        'B': {
+            'foo': 'test'
+        }
+    }
+
+    cfg = StructConfig(dictionary)
+    
+    print(cfg.a)     # 456
+    print(cfg.B.FOO) # World
+    
+    """
+    def __init__(self, dictionary, path="", env_prefix=""):
+        self._data = {}
+        self._env_prefix = env_prefix
+        for key, value in dictionary.items():
+            normalized_key = key.lower()
+            full_key = f"{path}_{normalized_key}" if path else normalized_key
+            self._data[normalized_key] = self._wrap(value, full_key)
+
+    def _wrap(self, value, path):
+        if isinstance(value, (tuple, list, set, frozenset)):
+            return type(value)([self._wrap(v, path) for v in value])
+        elif isinstance(value, dict):
+            return StructConfig(value, path, self._env_prefix)
+        else:
+            if self._env_prefix:
+                path = f"{self._env_prefix}_{path}"
+            ev = os.getenv(path.upper())
+            if not ev: return value
+            return self._convert(ev, value)
+
+    def __getattr__(self, key):
+        normalized_key = key.lower()
+        try:
+            return self._data[normalized_key]
+        except KeyError:
+            raise AttributeError(f"'{type(self).__name__}' object has no attribute '{key}'")
+
+    def __setattr__(self, key, value):
+        if key == "_data":
+            super().__setattr__(key, value)
+        else:
+            self._data[key.lower()] = value
+    def __getitem__(self, key):
+        try:
+            return self._data[key.lower()]
+        except KeyError:
+            raise KeyError(f"Key '{key.lower()}' not found")
+
+    def __setitem__(self, key, value):
+        self._data[key.lower()] = value
+
+    def __delitem__(self, key):
+        normalized_key = key.lower()
+        try:
+            del self._data[normalized_key]
+        except KeyError:
+            raise KeyError(f"Key '{key}' not found")
+
+    def __str__(self) -> str:
+        return str(self._data)
+
+    @staticmethod
+    def _convert(value, original_value):
+        """
+        Keep the environment variable type the same as the yaml value type
+        """
+        original_type = type(original_value)
+        try:
+            if original_type == int:
+                return int(value)
+            elif original_type == float:
+                return float(value)
+            elif original_type == bool:
+                return value.lower() in ('yes', 'true', 't', '1')
+            else:
+                return value
+        except ValueError:
+            logging.error(f"Error: Cannot convert '{value}' to {original_type}, using yaml vaule {original_value}")
+            return original_value
 
 class AbsConfigReader(ABC):
     """
@@ -80,11 +188,11 @@ class YamlFileConfigReader(FileConfigReader):
         finally:
             self.file_lock.release()
 
-    def read_data_from_file(self) -> dict:
+    def read_data_from_file(self) -> StructConfig:
         conf = yaml.safe_load(self.read_file())
         if conf is None:
             conf = {}
-        return conf
+        return StructConfig(conf, env_prefix="KUBESPIDER")
 
     def write_data_to_file(self, data: dict):
         self.write_file(yaml.dump(data, allow_unicode=True, sort_keys=False))
@@ -99,8 +207,11 @@ class YamlFileSectionConfigReader(YamlFileConfigReader):
         super().__init__(file_path)
         self.section = section
 
-    def read(self) -> dict:
-        return super().read()[self.section]
+    def read(self) -> StructConfig:
+        data = super().read()
+        for s in self.section.split('.'):
+            data = data[s]
+        return data
 
     def save(self, new_data: dict):
         super().parcial_update(lambda data: data.update({self.section: new_data}))

--- a/kubespider/utils/global_config.py
+++ b/kubespider/utils/global_config.py
@@ -1,11 +1,10 @@
-import logging
 import os
 import os.path as osp
 from enum import Enum
 
 import yaml
 
-from utils.config_reader import YamlFileConfigReader
+from utils.config_reader import YamlFileConfigReader, StructConfig
 
 CFG_BASE_PATH = os.getenv('KUBESPIDER_HOME', '/data/kubespider')
 
@@ -42,12 +41,14 @@ class PathConfig(str, Enum):
 
 def get_global_config() -> YamlFileConfigReader:
     if not osp.exists(PathConfig.KUBESPIDER_CONFIG.config_path()):
+        os.makedirs(CFG_BASE_PATH, exist_ok=True)
+        os.makedirs(PathConfig.SOURCE_PROVIDERS_BIN.config_path(), exist_ok=True)
         data = yaml.safe_load(default_yaml)
         with open(PathConfig.KUBESPIDER_CONFIG.config_path(), 'w') as file:
             yaml.safe_dump(data, file)
     return YamlFileConfigReader(PathConfig.KUBESPIDER_CONFIG.config_path())
 
-cfg = get_global_config().read()
+cfg: StructConfig = get_global_config().read()
 
 class Config(object):
     SQLALCHEMY_DATABASE_URI = f"sqlite:///{osp.join(CFG_BASE_PATH, 'kubespider.db')}"
@@ -65,10 +66,3 @@ class Config(object):
     SECRET_KEY = cfg.webapi.secret_key
     
     DOWNLOAD_BASE_PATH = cfg.download.base_path
-
-def initdirs():
-    """
-    Initialize the necessary folders
-    """
-    os.makedirs(CFG_BASE_PATH, exist_ok=True)
-    os.makedirs(PathConfig.SOURCE_PROVIDERS_BIN.config_path(), exist_ok=True)

--- a/kubespider/utils/global_config.py
+++ b/kubespider/utils/global_config.py
@@ -1,26 +1,74 @@
 import logging
-from utils import values
+import os
+import os.path as osp
+from enum import Enum
+
+import yaml
+
 from utils.config_reader import YamlFileConfigReader
-from utils.values import CFG_BASE_PATH
+
+CFG_BASE_PATH = os.getenv('KUBESPIDER_HOME', '/data/kubespider')
+
+default_yaml = """
+---
+log:
+  level: 'INFO'
+proxy: ""
+webapi:
+  server_port: 3080
+  auth_token: ""
+  secret_key: iECgbYWReMNxkRprrzMo5KAQYnb2UeZ3bwvReTSt+VSESW0OB8zbglT+6rEcDW9X
+statemachine:
+  task_queue_size: 100
+  event_queue_size: 100
+download:
+  base_path: /downloads
+"""
+
+class PathConfig(str, Enum):
+    KUBESPIDER_CONFIG = 'kubespider.yaml'
+    DEPENDENCIES_CONFIG = 'dependencies/'
+    SOURCE_PROVIDERS_BIN = 'providers/source_bin'
+    SOURCE_PROVIDERS_CONF = 'providers/source'
+    DOWNLOAD_PROVIDERS_CONF = 'providers/download'
+    NOTIFICATION_PROVIDERS_CONF = 'providers/notification'
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    def config_path(self) -> str:
+        return os.path.join(CFG_BASE_PATH, self)
 
 
 def get_global_config() -> YamlFileConfigReader:
-    return YamlFileConfigReader(values.Config.KUBESPIDER_CONFIG.config_path())
-
+    if not osp.exists(PathConfig.KUBESPIDER_CONFIG.config_path()):
+        data = yaml.safe_load(default_yaml)
+        with open(PathConfig.KUBESPIDER_CONFIG.config_path(), 'w') as file:
+            yaml.safe_dump(data, file)
+    return YamlFileConfigReader(PathConfig.KUBESPIDER_CONFIG.config_path())
 
 cfg = get_global_config().read()
 
-
 class Config(object):
-    SQLALCHEMY_DATABASE_URI = f"sqlite:///{CFG_BASE_PATH}kubespider.db"
+    SQLALCHEMY_DATABASE_URI = f"sqlite:///{osp.join(CFG_BASE_PATH, 'kubespider.db')}"
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SQLALCHEMY_COMMIT_ON_TEARDOWN = True
-    SECRET_KEY = "iECgbYWReMNxkRprrzMo5KAQYnb2UeZ3bwvReTSt+VSESW0OB8zbglT+6rEcDW9X"
     SESSION_USE_SIGNER = True
     SESSION_PERMANENT = False
     PERMANENT_SESSION_LIFETIME = 86400 * 2
-    LOG_LEVEL = logging.INFO
-    AUTH_TOKEN = cfg.get('auth_token', None)
-    PROXY = cfg.get('proxy', "")
-    SERVER_PORT = cfg.get('server_port', 3080)
-    DOWNLOAD_BASE_PATH = cfg.get("download", {}).get("base_path", "/downloads")
+    
+    LOG_LEVEL = cfg.log.level
+    PROXY = cfg.proxy
+    
+    SERVER_PORT = cfg.webapi.server_port
+    AUTH_TOKEN = cfg.webapi.auth_token
+    SECRET_KEY = cfg.webapi.secret_key
+    
+    DOWNLOAD_BASE_PATH = cfg.download.base_path
+
+def initdirs():
+    """
+    Initialize the necessary folders
+    """
+    os.makedirs(CFG_BASE_PATH, exist_ok=True)
+    os.makedirs(PathConfig.SOURCE_PROVIDERS_BIN.config_path(), exist_ok=True)

--- a/kubespider/utils/helper.py
+++ b/kubespider/utils/helper.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse
 import requests
 
 from utils import values
-from utils.global_config import Config
+from utils.global_config import PathConfig, Config
 from utils.types import LinkType, ProviderType
 
 
@@ -153,11 +153,11 @@ def parse_func_doc(func):
 
 def get_provider_conf_base_path(provider_type):
     if provider_type == ProviderType.download_provider:
-        base_path = values.Config.DOWNLOAD_PROVIDERS_CONF.config_path()
+        base_path = PathConfig.DOWNLOAD_PROVIDERS_CONF.config_path()
     elif provider_type == ProviderType.notification_provider:
-        base_path = values.Config.NOTIFICATION_PROVIDERS_CONF.config_path()
+        base_path = PathConfig.NOTIFICATION_PROVIDERS_CONF.config_path()
     elif provider_type == ProviderType.source_provider:
-        base_path = values.Config.SOURCE_PROVIDERS_CONF.config_path()
+        base_path = PathConfig.SOURCE_PROVIDERS_CONF.config_path()
     else:
         raise Exception(f"Unknown Provider Type: {provider_type}")
     return base_path

--- a/kubespider/utils/values.py
+++ b/kubespider/utils/values.py
@@ -1,10 +1,9 @@
 # Used to define the general values used in the project
 import hashlib
 import os
-from enum import Enum
 from io import BytesIO
 
-from utils.config_reader import YamlFileConfigReader
+from utils.global_config import cfg
 from utils.types import FileType, DownloadStates
 
 FILE_TYPE_TO_PATH = {
@@ -16,25 +15,6 @@ FILE_TYPE_TO_PATH = {
     FileType.picture: "Picture",
     FileType.pt: "PT"
 }
-
-CFG_BASE_PATH = os.path.join(os.getenv('HOME'), '.config/')
-CFG_TEMPLATE_PATH = os.path.join(os.getenv('HOME'), '.config_template/')
-
-
-class Config(str, Enum):
-    KUBESPIDER_CONFIG = 'kubespider.yaml'
-    DEPENDENCIES_CONFIG = 'dependencies/'
-    SOURCE_PROVIDERS_BIN = 'providers/source_bin'
-    SOURCE_PROVIDERS_CONF = 'providers/source'
-    DOWNLOAD_PROVIDERS_CONF = 'providers/download'
-    NOTIFICATION_PROVIDERS_CONF = 'providers/notification'
-
-    def __str__(self) -> str:
-        return str(self.value)
-
-    def config_path(self) -> str:
-        return os.path.join(CFG_BASE_PATH, self)
-
 
 class CallMode:
     def __init__(self, **kwargs):
@@ -163,8 +143,7 @@ class DownloadTask:
 
     @staticmethod
     def _get_download_path(path):
-        cfg = YamlFileConfigReader(Config.KUBESPIDER_CONFIG.config_path()).read()
-        download_base_path = cfg.get("download", {}).get("base_path", "/downloads")
+        download_base_path = cfg.download.base_path
         if path:
             if path.startswith('/'):
                 return path


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

- Modify the configuratiuon file read policy

Now, KubeSpider will check whether the configuration file exists. If it does not exist, it will automatically create a default configuration file in the specified directory and run it. The specified directory can be specified through the environment variable `KUBESPIDER_HOME`. The default path is `/data/kubespider`

For local developer, there is no need to conflict with the original system `HOME` env var.
```
KUBESPIDER_HOME=$HOME/.config/kubespider python kubespider/app.py
```

Subsequent sqlite files and source_provider bins will be uniformly saved in the KUBESPIDER_HOME directory.
```
❯ tree $KUBESPIDER_HOME
/root/.config/kubespider
├── kubespider.db
├── kubespider.yaml
└── providers
    └── source_bin
        └── mikanani_provider

3 directories, 3 file
```

- Support for env vars override

Now, KubeSpider supports reading environment variables to overwrite configurations read from `$KUBESPIDER_HOME/kubespider.yaml`, which facilitates container startup and local debugging.

- Add logging level config

Now, KubeSpider supports setting the logging level from the `$KUBESPIDER_HOME/kubespider.yaml` or env var `KUBESPIDER_LOG_LEVEL` to change the logging mode, only support for "DEBUG" and "INFO" 

```
# $HOME/.config/kubespider/kubespider.yaml
...
log:
    level: INFO
webapi:
    server_port: 3080
...

> KUBESPIDER_HOME=$HOME/.config/kubespider \
  KUBESPIDER_WEBAPI_SERVER_PORT=4080 \
  KUBESPIDER_LOG_LEVEL=DEBUG \
  python kubespider/app.py

2023-12-25 19:19:50,705-INFO runner.py[line11]: Webhook Server start running...
2023-12-25 19:19:50,724-INFO manager.py[line38]: [DownloadManager] instance reload success ...
2023-12-25 19:19:50,726-INFO manager.py[line28]: [SourceManager] instance reload success ...
2023-12-25 19:19:50,727-INFO manager.py[line47]: [NotificationManager] instance reload success ...
2023-12-25 19:19:50,738-DEBUG selector_events.py[line54]: Using selector: EpollSelector
2023-12-25 19:19:50,740-INFO wasyncore.py[line486]: Serving on http://0.0.0.0:4080
```
