### PR TITLE
fix: yutto downloader not recognize url from app

### DIFF
--- a/kubespider/download_provider/yutto_download_provider/provider.py
+++ b/kubespider/download_provider/yutto_download_provider/provider.py
@@ -1,6 +1,5 @@
 import logging
 import json
-import re
 from utils.config_reader import AbsConfigReader
 from utils.helper import get_request_controller
 from download_provider.provider import DownloadProvider

--- a/kubespider/download_provider/yutto_download_provider/provider.py
+++ b/kubespider/download_provider/yutto_download_provider/provider.py
@@ -1,5 +1,6 @@
 import logging
 import json
+import re
 from utils.config_reader import AbsConfigReader
 from utils.helper import get_request_controller
 from download_provider.provider import DownloadProvider
@@ -36,10 +37,11 @@ class YuttoDownloadProvider(DownloadProvider):
 
     def send_general_task(self, task: Task) -> TypeError:
         headers = {'Content-Type': 'application/json'}
+        task.url = re.findall(r"https?://\S+", task.url)[0]
         data = {'dataSource': task.url, 'path': task.path}
         logging.info('Send general task:%s', json.dumps(data))
 
-        if not task.url.startswith('https://www.bilibili.com'):
+        if not (task.url.startswith('https://www.bilibili.com') or task.url.startswith('https://b23.tv')):
             return TypeError('yutto only support specific resource')
 
         # This downloading tasks is special, other download software could not handle

--- a/kubespider/download_provider/yutto_download_provider/provider.py
+++ b/kubespider/download_provider/yutto_download_provider/provider.py
@@ -37,7 +37,6 @@ class YuttoDownloadProvider(DownloadProvider):
 
     def send_general_task(self, task: Task) -> TypeError:
         headers = {'Content-Type': 'application/json'}
-        task.url = re.findall(r"https?://\S+", task.url)[0]
         data = {'dataSource': task.url, 'path': task.path}
         logging.info('Send general task:%s', json.dumps(data))
 

--- a/kubespider/source_provider/bilibili_source_provider/provider.py
+++ b/kubespider/source_provider/bilibili_source_provider/provider.py
@@ -64,7 +64,7 @@ class BilibiliSourceProvider(provider.SourceProvider):
         event.put_extra_params(self.get_download_param())
 
         return [Resource(
-            url=event.source,
+            url=re.findall(r"https?://\S+", event.source)[0],
             path='',
             link_type=self.get_link_type(),
             file_type=types.FILE_TYPE_VIDEO_MIXED,

--- a/kubespider/source_provider/bilibili_source_provider/provider.py
+++ b/kubespider/source_provider/bilibili_source_provider/provider.py
@@ -2,6 +2,7 @@
 # Function: download single video link
 # encoding:utf-8
 import logging
+import re
 from urllib.parse import urlparse
 
 from source_provider import provider
@@ -52,7 +53,7 @@ class BilibiliSourceProvider(provider.SourceProvider):
         return self.webhook_enable
 
     def should_handle(self, event: Event) -> bool:
-        parse_url = urlparse(event.source)
+        parse_url = urlparse(re.findall(r"https?://\S+", event.source)[0])
         if parse_url.hostname in ('www.bilibili.com', 'b23.tv'):
             logging.info('%s belongs to BilibiliSourceProvider', event.source)
             return True


### PR DESCRIPTION
fix: yutto downloader does not recognize url pasted/shared from mobile app

```release-note
fix: yutto downloader does not recognize url pasted/shared from mobile app
```