### PR TITLE
chore: bump yutto version to `2.0.0-beta.37` and fix typo in code

### DIFF
--- a/downloaders/yutto/app/core/tasks.py
+++ b/downloaders/yutto/app/core/tasks.py
@@ -15,7 +15,7 @@ class DownloadTask:
         self.fail_count = count
 
 
-class YouGetTasks:
+class YuttoTasks:
     def __init__(self) -> None:
         self.paralel_num = 4
         self.fail_threshold = 3
@@ -90,4 +90,4 @@ class YouGetTasks:
     def equeue(self, tasks: list) -> None:
         self.queue.put(tasks)
 
-yutto_tasks = YouGetTasks()
+yutto_tasks = YuttoTasks()

--- a/downloaders/yutto/requirements.txt
+++ b/downloaders/yutto/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.31.0
 flask==2.2.5
-yutto==2.0.0b33
+yutto==2.0.0b37


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* bump yutto version to `2.0.0-beta.37`, see more details in:
    - https://github.com/yutto-dev/yutto/releases/tag/v2.0.0-beta.34
    - https://github.com/yutto-dev/yutto/releases/tag/v2.0.0-beta.35
    - https://github.com/yutto-dev/yutto/releases/tag/v2.0.0-beta.36
    - https://github.com/yutto-dev/yutto/releases/tag/v2.0.0-beta.37
* replace `YouGetTasks` with `YuttoTasks` in yutto downloader

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
- bump yutto version to `2.0.0-beta.37`
```