### PR TITLE
fix: wrong xunlei version for auto token retrieval

### DIFF
--- a/kubespider/download_provider/xunlei_download_provider/provider.py
+++ b/kubespider/download_provider/xunlei_download_provider/provider.py
@@ -224,7 +224,7 @@ class XunleiDownloadProvider(provider.DownloadProvider):
 
     def get_pan_token(self) -> str:
         server_version = self.get_server_version()
-        if check_version_at_lest(server_version, "1.21.1"):
+        if check_version_at_lest(server_version, "3.21.0"):
             if self._token_str is not None:
                 return self._token_str
             resp = self.request_handler.get(self.http_endpoint + '/webman/3rdparty/pan-xunlei-com/index.cgi/',


### PR DESCRIPTION
正确的版本应为 3.21.0

Fixes #508

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* fix: wrong xunlei version for auto token retrieval in #505

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
- fix: wrong xunlei version for auto token retrieval
```