### PR TITLE
对迅雷的一些优化

### DIFF
--- a/docs/zh/user_guide/thunder_install_config/README.md
+++ b/docs/zh/user_guide/thunder_install_config/README.md
@@ -108,3 +108,6 @@ xunlei:
 docker restart kubespider
 ```
 按最终效果图测试一下即可。
+
+#### 8.自动获取
+[#505](https://github.com/opennaslab/kubespider/pull/505) `3.21.0` 之后迅雷版本会自动获取 `device_id` `token`

--- a/kubespider/download_provider/xunlei_download_provider/provider.py
+++ b/kubespider/download_provider/xunlei_download_provider/provider.py
@@ -224,7 +224,14 @@ class XunleiDownloadProvider(provider.DownloadProvider):
         file_count = int(file_info['list']['resources'][0]['file_count'])
         if file_count == 1:
             return '--1,'
-        return '0-' + str(file_count - 1)
+        max_sub_file_idx=0
+        for sub_file_obj in file_info['list']['resources'][0]["dir"]["resources"]:
+            if (
+                "file_index" in sub_file_obj
+                and sub_file_obj["file_index"] > max_sub_file_idx
+            ):
+                max_sub_file_idx = sub_file_obj["file_index"]
+        return f"0-{max_sub_file_idx}"
 
     def get_pan_token(self) -> str:
         server_version = self.get_server_version()

--- a/kubespider/source_provider/btbtt12_disposable_source_provider/provider.py
+++ b/kubespider/source_provider/btbtt12_disposable_source_provider/provider.py
@@ -56,6 +56,8 @@ class Btbtt12DisposableSourceProvider(provider.SourceProvider):
 
     def should_handle(self, event: Event) -> bool:
         parse_url = urlparse(event.source)
+        if not parse_url:
+            return False
         if parse_url.hostname.endswith('btbtt12.com') and 'attach-dialog-fid' in parse_url.path:
             logging.info('%s belongs to Btbtt12DisposableSourceProvider', event.source)
             return True


### PR DESCRIPTION
例如：
可能存在下标不连续情况
```json
{
    "type": "user#download-url",
    "name": "哪吒之魔童降世.国粤英.Ne.Zha.2019.BD1080P&2160P.X264.DTS-HD.MA.7.1.Mandarin&Cantonese&English.CHS-ENG.FFans@星星",
    "file_name": "哪吒之魔童降世.国粤英.Ne.Zha.2019.BD1080P&2160P.X264.DTS-HD.MA.7.1.Mandarin&Cantonese&English.CHS-ENG.FFans@星星",
    "file_size": "33595559143",
    "space": "device_id#fcff376dffcfa69fae64eec2d7408391",
    "params": {
        "target": "device_id#fcff376dffcfa69fae64eec2d7408391",
        "url": "magnet:?xt=urn:btih:123154AEBE22EB9811FF501A7E1BE1824E0C8298",
        "total_file_count": "6",
        "parent_folder_id": "14c0745bb3e71c518163c7c3bced2cb7",
        "sub_file_index": "0,2,4,6,8,10",
        "mime_type": "",
        "file_id": ""
    }
}
```

不知道解析了什么返回None的情况
```text
kubespider-kubespider-1  |   File "/app/kubespider/source_provider/btbtt12_disposable_source_provider/provider.py", line 59, in should_handle
kubespider-kubespider-1  |     if parse_url.hostname.endswith('btbtt12.com') and 'attach-dialog-fid' in parse_url.path:
kubespider-kubespider-1  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
kubespider-kubespider-1  | AttributeError: 'NoneType' object has no attribute 'endswith'
```
[#505](https://github.com/opennaslab/kubespider/pull/505) `3.21.0` 之后迅雷版本会自动获取 `device_id` `token`

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```