### PR TITLE
Bypass Cloudflare TOS

### DIFF
--- a/kubespider/source_provider/ani_source_provider/provider.py
+++ b/kubespider/source_provider/ani_source_provider/provider.py
@@ -158,37 +158,37 @@ class AniSourceProvider(provider.SourceProvider):
 
     def get_links_from_xml(self, tmp_xml, blacklist) -> list[Resource]:
         try:
-            xml_parse = ET.parse(tmp_xml)
-            items = xml_parse.findall('.//item')
             ret = []
-            for i in items:
-                xml_title = i.find('./title').text
+            for item in ET.parse(tmp_xml).findall('.//item'):
+                xml_title = item.find('./title').text
                 item_title, item_episode = self.get_anime_info(xml_title)
-                season, season_keyword = self.get_season(xml_title)
-                if item_title is not None:
-                    logging.info('Found Anime "%s" Season %s Episode %s', item_title, season, item_episode)
-                    # Pass blacklist Animes
-                    if self.check_blacklist(xml_title, blacklist):
-                        continue
-                    final_url = i.find('./guid').text
-                    if 'resources.ani.rip' in final_url:
-                        final_url = final_url.replace('resources.ani.rip', 'cloud.ani-download.workers.dev')
-                    res = Resource(
-                        url=final_url,
-                        path=self.save_path + (f'/{item_title}' if self.classification_on_directory else ''),
-                        file_type=types.FILE_TYPE_VIDEO_TV,
-                        link_type=self.get_link_type(),
-                    )
-                    if self.api_type == 'torrent':
-                        if self.use_sub_category:
-                            sub_category = self.get_subcategory(item_title, season, season_keyword)
-                            logging.info("Using subcategory: %s", sub_category)
-                            res.put_extra_params({'sub_category': sub_category})
-                    elif season > 1:
-                        res.put_extra_params({'file_name': self.rename_season(xml_title, season, season_keyword, item_episode)})
-                    ret.append(res)
-                else:
+                
+                if item_title is None or self.check_blacklist(xml_title, blacklist):
                     continue
+                    
+                season, season_keyword = self.get_season(xml_title)
+                logging.info('Found Anime "%s" Season %s Episode %s', item_title, season, item_episode)
+                
+                final_url = item.find('./guid').text
+                if 'resources.ani.rip' in final_url:
+                    final_url = final_url.replace('resources.ani.rip', 'cloud.ani-download.workers.dev')
+                
+                res = Resource(
+                    url=final_url,
+                    path=self.save_path + (f'/{item_title}' if self.classification_on_directory else ''),
+                    file_type=types.FILE_TYPE_VIDEO_TV,
+                    link_type=self.get_link_type(),
+                )
+                
+                if self.api_type == 'torrent' and self.use_sub_category:
+                    sub_category = self.get_subcategory(item_title, season, season_keyword)
+                    logging.info("Using subcategory: %s", sub_category)
+                    res.put_extra_params({'sub_category': sub_category})
+                elif season > 1:
+                    res.put_extra_params({'file_name': self.rename_season(xml_title, season, season_keyword, item_episode)})
+                    
+                ret.append(res)
+                
             return ret
         except Exception as err:
             print(traceback.format_exc())

--- a/kubespider/source_provider/ani_source_provider/provider.py
+++ b/kubespider/source_provider/ani_source_provider/provider.py
@@ -170,8 +170,11 @@ class AniSourceProvider(provider.SourceProvider):
                     # Pass blacklist Animes
                     if self.check_blacklist(xml_title, blacklist):
                         continue
+                    final_url = i.find('./guid').text
+                    if 'resources.ani.rip' in final_url:
+                        final_url = final_url.replace('resources.ani.rip', 'cloud.ani-download.workers.dev')
                     res = Resource(
-                        url=i.find('./guid').text,
+                        url=final_url,
                         path=self.save_path + (f'/{item_title}' if self.classification_on_directory else ''),
                         file_type=types.FILE_TYPE_VIDEO_TV,
                         link_type=self.get_link_type(),


### PR DESCRIPTION


<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Calling aria2 to download a link from the ANi API using the domain name `resources.ani.rip` has a high probability of being intercepted by its Cloudflare security mechanism and returning a 12kb TOS video, so replace the domain name of the download link with the real resolved `cloud.ani-download.workers.dev`
![image](https://github.com/user-attachments/assets/85ed5827-4dca-4df1-bda3-24cf568575dc)
