### PR TITLE
Fix: 强制指定文件名，以避免服务器返回无后缀filename

### DIFF
--- a/kubespider/source_provider/ani_source_provider/provider.py
+++ b/kubespider/source_provider/ani_source_provider/provider.py
@@ -184,9 +184,12 @@ class AniSourceProvider(provider.SourceProvider):
                     sub_category = self.get_subcategory(item_title, season, season_keyword)
                     logging.info("Using subcategory: %s", sub_category)
                     res.put_extra_params({'sub_category': sub_category})
-                elif season > 1:
+                
+                if season > 1:
                     res.put_extra_params({'file_name': self.rename_season(xml_title, season, season_keyword, item_episode)})
-                    
+                else:
+                    res.put_extra_params({'file_name': xml_title})
+                
                 ret.append(res)
                 
             return ret


### PR DESCRIPTION
<img width="1906" height="1037" alt="image" src="https://github.com/user-attachments/assets/e89ff585-47d5-4e84-8079-6bc87e3cf287" />

在前几天的运行过程中发现有部分下载任务落盘的文件不带后缀名，但是Season 2以上的文件不受此影响。
查阅源码后发现，Season 2以上的文件名，是我通过解析器处理xml的title得到，但Season 1只是单纯的发送下载链接，其它事情交由download provider和服务器自行协商。
<img width="2309" height="522" alt="image" src="https://github.com/user-attachments/assets/2f9d1939-38a0-43a6-bbce-e68ebff949c0" />
询问API管理员，收到的答复称该现象无法避免，因此在代码中给Season 1也强制指定了文件名
<img width="393" height="150" alt="image" src="https://github.com/user-attachments/assets/b20dce1e-dc28-40ba-809b-771a1c614499" />
